### PR TITLE
fix: watchの対象を参照からroom.idに修正

### DIFF
--- a/vue/src/views/ChatRoom.vue
+++ b/vue/src/views/ChatRoom.vue
@@ -518,7 +518,7 @@ export default {
     this.disconnectCable();
   },
   watch: {
-    room() {
+    "room.id"() {
       this.connectCable();
     },
   },


### PR DESCRIPTION
# What
watch対象をroomからroom.idに修正

# Why
Room情報取得のたびにWebSocket接続処理が走ってしまうため